### PR TITLE
`sandbox.create()` is deprecated. Use default sandbox at `sinon.sandb…

### DIFF
--- a/test/sandbox.js
+++ b/test/sandbox.js
@@ -2,7 +2,7 @@
 const stripAnsi = require('strip-ansi');
 const log = require('fancy-log');
 const sinon = require('sinon');
-const sandbox = sinon.sandbox.create();
+const sandbox = sinon.createSandbox();
 
 beforeEach(() => {
 	sandbox.stub(log, 'warn');


### PR DESCRIPTION
…ox` or create new sandboxes with `sinon.createSandbox()`